### PR TITLE
Be more specific about docker versions in test

### DIFF
--- a/tests/NLoop.Server.Tests/Dockerfiles/litecoin
+++ b/tests/NLoop.Server.Tests/Dockerfiles/litecoin
@@ -6,11 +6,11 @@ RUN set -ex \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV LITECOIN_VERSION 0.18.1
-ENV LITECOIN_FILE litecoin-0.18.1-x86_64-linux-gnu.tar.gz
-ENV LITECOIN_URL https://download.litecoin.org/litecoin-0.18.1/linux/
+ENV LITECOIN_FILE litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz
+ENV LITECOIN_URL https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/
 ENV LITECOIN_SHA256 ca50936299e2c5a66b954c266dcaaeef9e91b2f5307069b9894048acf3eb5751
 
-ENV LITECOIN_ASC_URL https://download.litecoin.org/litecoin-0.18.1/linux/litecoin-0.18.1-x86_64-linux-gnu.tar.gz.asc
+ENV LITECOIN_ASC_URL https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz.asc
 ENV LITECOIN_PGP_KEY FE3348877809386C
 # 01EA5486DE18A882D4C2684590C8019E36C2E964
 

--- a/tests/NLoop.Server.Tests/docker-compose.yml
+++ b/tests/NLoop.Server.Tests/docker-compose.yml
@@ -6,9 +6,11 @@ services:
     build:
       context: ./Dockerfiles
       dockerfile: bitcoin
+      args:
+        VERSION: 22.0
       cache_from:
-        - nloop/bitcoind:latest
-    image: nloop/bitcoind
+        - nloop/bitcoind:22.0
+    image: nloop/bitcoind:22.0
     environment:
       BITCOIN_NETWORK: regtest
       BITCOIN_RPC_AUTH: johndoe:75669617aaedb394397ddc7213bb1ea9$$3a50ee2f4dff3cd49475295124aa3d48a61d6ae3cdcb4d2cf199dac6551217f4
@@ -49,9 +51,11 @@ services:
     build:
       context: ./Dockerfiles
       dockerfile: litecoin
+      args:
+        LITECOIN_VERSION: 18.1
       cache_from:
-        - nloop/litecoind:latest
-    image: nloop/litecoind
+        - nloop/litecoind:18.1
+    image: nloop/litecoind:18.1
     environment:
       LITECOIN_NETWORK: regtest
       LITECOIN_RPC_AUTH: johndoe:75669617aaedb394397ddc7213bb1ea9$$3a50ee2f4dff3cd49475295124aa3d48a61d6ae3cdcb4d2cf199dac6551217f4
@@ -81,12 +85,14 @@ services:
       - "./data/litecoin:/data"
   lnd_user:
     restart: unless-stopped
-    image: nloop/lnd
+    image: nloop/lnd:v0.14.1-beta
     build:
       context: ./Dockerfiles
       dockerfile: lnd
+      args:
+        LND_VERSION: v0.14.1-beta
       cache_from:
-        - nloop/lnd:latest
+        - nloop/lnd:v0.14.1-beta
     environment:
       LND_ENVIRONMENT: regtest
       LND_REST_PORT: 32736
@@ -136,12 +142,14 @@ services:
       - "./data/bitcoin:/deps/.bitcoin"
   lnd_server_btc:
     restart: unless-stopped
-    image: nloop/lnd
+    image: nloop/lnd:v0.14.1-beta
     build:
       context: ./Dockerfiles
       dockerfile: lnd
+      args:
+        LND_VERSION: v0.14.1-beta
       cache_from:
-        - nloop/lnd:latest
+        - nloop/lnd:v0.14.1-beta
     environment:
       LND_ENVIRONMENT: regtest
       LND_REST_PORT: 32737
@@ -189,12 +197,14 @@ services:
 
   lnd_server_ltc:
     restart: unless-stopped
-    image: nloop/lnd
+    image: nloop/lnd:v0.14.1-beta
     build:
       context: ./Dockerfiles
       dockerfile: lnd
+      args:
+        LND_VERSION: v0.14.1-beta
       cache_from:
-        - nloop/lnd:latest
+        - nloop/lnd:v0.14.1-beta
     environment:
       LND_ENVIRONMENT: regtest
       LND_REST_PORT: 32737
@@ -239,14 +249,16 @@ services:
       - "./data/litecoin:/deps/.litecoin"
 
   boltz:
-    image: nloop/boltz
+    image: nloop/boltz:490d2a605bd7dae20a795607d61f5c722ab42054
     container_name: boltz
     restart: unless-stopped
     build:
       context: ./Dockerfiles
+      args:
+        BOLTZ_VERSION: 490d2a605bd7dae20a795607d61f5c722ab42054
       dockerfile: boltz
       cache_from:
-        - nloop/boltz:latest
+        - nloop/boltz:490d2a605bd7dae20a795607d61f5c722ab42054
     command:
       - "--configpath=/data/boltz/boltz.conf"
     expose:
@@ -264,13 +276,15 @@ services:
       - "lnd_server_ltc"
 
   esdb:
-    image: nloop/esdb
+    image: nloop/esdb:oss-v20.10.2
     container_name: esdb
     build:
+      args:
+        EVENTSTORE_VERSION: oss-v20.10.2
       context: ./Dockerfiles
       dockerfile: esdb
       cache_from:
-        - nloop/esdb:latest
+        - nloop/esdb:oss-v20.10.2
     restart: unless-stopped
     environment:
       - EVENTSTORE_INSECURE=true


### PR DESCRIPTION
* Before this commit, when we bump the version of images used in test,
  it requires users to run `docker-compose build` or otherwise
  keep using old version and cause an error in startup process.
  fix this problem by using more specific verions.