### PR TITLE
Make SwapTx detection more robust

### DIFF
--- a/NLoop.Domain/IO/DatabaseDTOs.fs
+++ b/NLoop.Domain/IO/DatabaseDTOs.fs
@@ -65,6 +65,7 @@ type LoopOut = {
   RedeemScript: Script
   Invoice: string
   ClaimAddress: string
+
   [<JsonConverter(typeof<MoneyJsonConverter>)>]
   OnChainAmount: Money
   [<JsonConverter(typeof<BlockHeightJsonConverter>)>]
@@ -100,6 +101,12 @@ type LoopOut = {
   member this.QuoteAssetNetwork =
     let struct (_, cryptoCode) = this.PairId.Value
     cryptoCode.ToNetworkSet().GetNetwork(this.ChainName |> ChainName)
+
+  member this.PossibleLockupAddress =
+    seq [
+      this.RedeemScript.WitHash.GetAddress(this.BaseAssetNetwork)
+      this.RedeemScript.WitHash.ScriptPubKey.Hash.GetAddress(this.BaseAssetNetwork)
+    ]
 
   member this.AcceptZeroConf =
     this.SwapTxConfRequirement = BlockHeightOffset32.Zero


### PR DESCRIPTION
* Before this commit, we search for swaptx by searching a
  TxId which server told us though sse. But the communication channel is
  less reliable than those to the blockchain, so we also search
  for the tx which has lockupaddress in the block. Thus it is now more
  reliable in case of non-0conf swap.