### PR TITLE
WIP: fix fee estimation bug in autoloop

### DIFF
--- a/LndClient/types.fs
+++ b/LndClient/types.fs
@@ -245,10 +245,20 @@ type WalletUtxo = {
     }
 
 
+type WalletClientError =
+  | InSufficientFunds of string
+  | RPCError of string
+
 type IWalletClient =
   abstract member FundToAddress: dest: BitcoinAddress * amount: Money * confTarget: BlockHeightOffset32 * ?ct: CancellationToken ->
     Task<uint256>
   abstract member GetDepositAddress: network: Network * ?ct: CancellationToken -> Task<BitcoinAddress>
+
+  abstract member GetSendingTxFee:
+    destinations: IDictionary<BitcoinAddress, Money> *
+      target: BlockHeightOffset32 *
+      ?ct: CancellationToken ->
+    Task<Result<Money, WalletClientError>>
 
 [<AbstractClass;Sealed;Extension>]
 type LightningClientExtensions =

--- a/NLoop.Server/QueryHandlers.fs
+++ b/NLoop.Server/QueryHandlers.fs
@@ -116,6 +116,8 @@ module QueryHandlers =
           |> fun a -> { GetCostSummaryResponse.Costs = a; ServerEndpoint = opts.Value.BoltzHost }
         return! json resp next ctx
     }
+
+  // todo: cache with projection?
   let handleGetCostSummary =
     fun (next: HttpFunc) (ctx: HttpContext) -> task {
       match ctx.TryGetDate("since") with

--- a/NLoop.Server/RPCDTOs/AutoLoop.fs
+++ b/NLoop.Server/RPCDTOs/AutoLoop.fs
@@ -31,7 +31,7 @@ type SwapDisqualifiedReason =
   member this.Message =
     match this with
     | SweepFeesTooHigh v ->
-      $"Current estimated FeeRate is {v.Estimation.SatoshiPerByte |> int64} sat/vbyte. But our limit is {v.OurLimit.SatoshiPerByte |> int64} sats/vbyte"
+      $"Current estimated FeeRate is {v.Estimation.SatoshiPerByte} sat/vbyte. But our limit for sweep_fee_rate is {v.OurLimit.SatoshiPerByte} sats/vbyte. You may want to set higher value for \"sweep_fee_rate_sat_per_kvbyte\""
     | MinerFeeTooHigh v  ->
       $"miner fee: ({v.ServerRequirement.Satoshi} sats) greater than our fee limit ({v.OurLimit.Satoshi} sats)"
     | SwapFeeTooHigh v ->

--- a/NLoop.Server/SwapServerClient/interfaces.fs
+++ b/NLoop.Server/SwapServerClient/interfaces.fs
@@ -216,8 +216,7 @@ module SwapDTO =
 
   type LoopInQuoteRequest = {
     Amount: Money
-    /// We don't need this since boltz does not require us to specify it.
-    // HtlcConfTarget: BlockHeightOffset32
+    HtlcConfTarget: BlockHeightOffset32
     Pair: PairId
   }
 
@@ -257,13 +256,27 @@ module SwapDTO =
     MaxSwapAmount: Money
   }
 
+
+/// Client performs the client side part of swaps.
+/// It works against boltz server (or possibly lightning-loop server or others.)
 type ISwapServerClient =
   abstract member LoopOut: request: SwapDTO.LoopOutRequest * ?ct: CancellationToken -> Task<SwapDTO.LoopOutResponse>
   abstract member LoopIn: request: SwapDTO.LoopInRequest * ?ct: CancellationToken -> Task<SwapDTO.LoopInResponse>
   abstract member GetNodes: ?ct: CancellationToken -> Task<SwapDTO.GetNodesResponse>
 
-  abstract member GetLoopOutQuote: request: SwapDTO.LoopOutQuoteRequest * ?ct: CancellationToken -> Task<SwapDTO.LoopOutQuote>
-  abstract member GetLoopInQuote: request: SwapDTO.LoopInQuoteRequest * ?ct: CancellationToken -> Task<SwapDTO.LoopInQuote>
+  /// Returns estimated costs for the client. for an on-chain fees, it must query with fee estimator instead of
+  /// relying to other sources so that it wont result to inconsistent estimation
+  /// It is mostly equivalent to [Client.LoopOutQuote](https://github.com/lightninglabs/loop/blob/f650071bca5895a1421574d6eddd70003439b363/client.go#L435)
+  /// in lightning loop
+  abstract member GetLoopOutQuote: request: SwapDTO.LoopOutQuoteRequest * ?ct: CancellationToken ->
+    Task<Result<SwapDTO.LoopOutQuote, string>>
+
+  /// Returns estimated costs for the client. for an on-chain fees, it must query with fee estimator instead of
+  /// relying to other sources so that it wont result to inconsistent estimation
+  /// It is mostly equivalent to [Client.LoopOutQuote](https://github.com/lightninglabs/loop/blob/f650071bca5895a1421574d6eddd70003439b363/client.go#L560)
+  /// in lightning loop
+  abstract member GetLoopInQuote: request: SwapDTO.LoopInQuoteRequest * ?ct: CancellationToken ->
+    Task<Result<SwapDTO.LoopInQuote, string>>
 
   abstract member GetLoopOutTerms: req: SwapDTO.OutTermsRequest * ?ct : CancellationToken -> Task<SwapDTO.OutTermsResponse>
   abstract member GetLoopInTerms: req: SwapDTO.InTermsRequest * ?ct : CancellationToken -> Task<SwapDTO.InTermsResponse>

--- a/tests/NLoop.Server.Tests/AutoLoopManagerTests.fs
+++ b/tests/NLoop.Server.Tests/AutoLoopManagerTests.fs
@@ -87,14 +87,14 @@ type private AutoLoopManagerTestContext() =
                 cts.CancelAfter(10)
                 let! expectedRequest, resp = this.QuotesOutChannel.Reader.ReadAsync(cts.Token)
                 Assert.Equal(expectedRequest, req)
-                return resp
+                return Ok resp
               }
               LoopInQuote = fun req -> task {
                 use cts = new CancellationTokenSource()
                 cts.CancelAfter(10)
                 let! expectedRequest, resp = this.QuotesInChannel.Reader.ReadAsync(cts.Token)
                 Assert.Equal(expectedRequest, req)
-                return resp
+                return Ok resp
               }
               LoopOutTerms = fun _ -> task {
                 return
@@ -632,10 +632,14 @@ type AutoLoopManagerTests() =
     }
     let quoteRequest1 = {
       SwapDTO.LoopInQuoteRequest.Amount = peer1ExpectedAmount
-      SwapDTO.LoopInQuoteRequest.Pair = loopInPair }
+      SwapDTO.LoopInQuoteRequest.Pair = loopInPair
+      SwapDTO.LoopInQuoteRequest.HtlcConfTarget = htlcConfTarget
+    }
     let quoteRequest2 = {
       SwapDTO.LoopInQuoteRequest.Amount = peer2ExpectedAmount
-      SwapDTO.LoopInQuoteRequest.Pair = loopInPair }
+      SwapDTO.LoopInQuoteRequest.Pair = loopInPair
+      SwapDTO.LoopInQuoteRequest.HtlcConfTarget = htlcConfTarget
+    }
     let peer1Swap = {
       LoopInRequest.Amount = peer1ExpectedAmount
       ChannelId = chanId1 |> Some
@@ -782,6 +786,7 @@ type AutoLoopManagerTests() =
     let loopInQuoteReq = {
       SwapDTO.LoopInQuoteRequest.Amount = loopInAmount
       SwapDTO.LoopInQuoteRequest.Pair = loopInPair
+      SwapDTO.LoopInQuoteRequest.HtlcConfTarget = htlcConfTarget
     }
     let loopInSwap =
       {
@@ -915,6 +920,7 @@ type AutoLoopManagerTests() =
     let loopInQuoteReq = {
       SwapDTO.LoopInQuoteRequest.Amount = loopInAmount
       SwapDTO.LoopInQuoteRequest.Pair = loopInPair
+      SwapDTO.LoopInQuoteRequest.HtlcConfTarget = htlcConfTarget
     }
     let loopInSwap =
       {

--- a/tests/NLoop.Server.Tests/LiquidityTest.fs
+++ b/tests/NLoop.Server.Tests/LiquidityTest.fs
@@ -304,8 +304,8 @@ type LiquidityTest() =
           {
             DummySwapServerClientParameters.Default
               with
-              LoopOutQuote = fun _ -> testQuote |> Task.FromResult
-              LoopInQuote = fun _ -> testInQuote |> Task.FromResult
+              LoopOutQuote = fun _ -> testQuote |> Ok |> Task.FromResult
+              LoopInQuote = fun _ -> testInQuote |> Ok |> Task.FromResult
           }
       let dummyLnClientProvider =
         TestHelpers.GetDummyLightningClientProvider
@@ -537,7 +537,7 @@ type LiquidityTest() =
           {
             DummySwapServerClientParameters.Default
               with
-              LoopOutQuote = fun _ -> quote |> Task.FromResult
+              LoopOutQuote = fun _ -> quote |> Ok |> Task.FromResult
           }
       services
         .AddSingleton<IFeeEstimator>(f)
@@ -767,7 +767,7 @@ type LiquidityTest() =
           {
             DummySwapServerClientParameters.Default
               with
-              LoopOutQuote = fun _ -> quote |> Task.FromResult
+              LoopOutQuote = fun _ -> quote |> Ok |> Task.FromResult
           }
       services
         .AddSingleton<ISwapServerClient>(swapServerClient)
@@ -944,7 +944,7 @@ type LiquidityTest() =
           {
             DummySwapServerClientParameters.Default
               with
-                LoopOutQuote = fun _ -> testQuote |> Task.FromResult
+                LoopOutQuote = fun _ -> testQuote |> Ok |> Task.FromResult
                 LoopOutTerms = fun _ ->
                   let r = outTerms.[callCount]
                   callCount <- callCount + 1
@@ -1066,7 +1066,7 @@ type LiquidityTest() =
             DummySwapServerClientParameters.Default
               with
                 LoopOutQuote = fun _ ->
-                  quote |> Task.FromResult
+                  quote |> Ok |> Task.FromResult
           }
       services
         .AddSingleton<ISwapServerClient>(swapClient)

--- a/tests/NLoop.Server.Tests/ServerAPITest.fs
+++ b/tests/NLoop.Server.Tests/ServerAPITest.fs
@@ -365,7 +365,7 @@ type ServerAPITest() =
           .AddSingleton<ISwapServerClient>(TestHelpers.GetDummySwapServerClient({
             DummySwapServerClientParameters.Default
               with
-                LoopOutQuote =  fun _req -> quote |> Task.FromResult
+                LoopOutQuote =  fun _req -> quote |> Ok |> Task.FromResult
                 GetNodes = fun () -> { Nodes = swapServerNodes }
                 LoopOut = fun _req -> responseFromServer |> Task.FromResult
           }))
@@ -475,7 +475,7 @@ type ServerAPITest() =
             .AddSingleton<ISwapServerClient>(TestHelpers.GetDummySwapServerClient({
               DummySwapServerClientParameters.Default
                 with
-                  LoopInQuote =  fun _req -> quote |> Task.FromResult
+                  LoopInQuote =  fun _req -> quote |> Ok |> Task.FromResult
                   LoopIn = fun _req -> responseFromServer |> Task.FromResult
             }))
             |> ignore

--- a/tests/NLoop.Server.Tests/SwapBuilderTests.fs
+++ b/tests/NLoop.Server.Tests/SwapBuilderTests.fs
@@ -52,8 +52,7 @@ type SwapBuilderTests() =
   let testConfig =
     {
       LoopInSwapBuilderDeps.GetLoopInQuote = fun req -> task {
-        let! res = TestHelpers.GetDummySwapServerClient().GetLoopInQuote(req)
-        return res |> Ok
+        return! TestHelpers.GetDummySwapServerClient().GetLoopInQuote(req)
       }
     }
 
@@ -94,6 +93,7 @@ type SwapBuilderTests() =
     let quoteRequest = {
       SwapDTO.LoopInQuoteRequest.Amount = swapAmount
       SwapDTO.LoopInQuoteRequest.Pair = pairId
+      SwapDTO.LoopInQuoteRequest.HtlcConfTarget = htlcConfTarget
     }
     let quote = {
       SwapDTO.LoopInQuote.SwapFee = Money.Satoshis(1L)
@@ -133,7 +133,7 @@ type SwapBuilderTests() =
         with
         GetLoopInQuote = fun req ->
           Assert.Equal(expectedQuoteRequest, req)
-          quote |> Result.mapError Exception |> Task.FromResult
+          quote |> Task.FromResult
     }
     let builder = SwapBuilder.NewLoopIn(config, NullLogger.Instance)
     let parameters = {

--- a/tests/NLoop.Server.Tests/TestHelpersMod.fs
+++ b/tests/NLoop.Server.Tests/TestHelpersMod.fs
@@ -137,8 +137,8 @@ type DummyLnClientParameters = {
   }
 
 type DummySwapServerClientParameters = {
-  LoopOutQuote: SwapDTO.LoopOutQuoteRequest -> Task<SwapDTO.LoopOutQuote>
-  LoopInQuote: SwapDTO.LoopInQuoteRequest -> Task<SwapDTO.LoopInQuote>
+  LoopOutQuote: SwapDTO.LoopOutQuoteRequest -> Task<Result<SwapDTO.LoopOutQuote, string>>
+  LoopInQuote: SwapDTO.LoopInQuoteRequest -> Task<Result<SwapDTO.LoopInQuote, string>>
   LoopOutTerms: SwapDTO.OutTermsRequest -> Task<SwapDTO.OutTermsResponse>
   LoopInTerms: SwapDTO.InTermsRequest -> Task<SwapDTO.InTermsResponse>
   GetNodes: unit -> SwapDTO.GetNodesResponse
@@ -154,7 +154,7 @@ type DummySwapServerClientParameters = {
         SwapDTO.LoopOutQuote.SwapPaymentDest = PubKey("02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619")
         SwapDTO.LoopOutQuote.CltvDelta = BlockHeightOffset32(20u)
         SwapDTO.LoopOutQuote.PrepayAmount = Money.Satoshis(10L)
-      } |> Task.FromResult
+      } |> Ok |> Task.FromResult
     LoopInQuote = fun _ -> failwith "todo"
     LoopOutTerms = fun _ ->
       {
@@ -310,10 +310,10 @@ type TestHelpers =
           parameters.GetNodes()
           |> Task.FromResult
 
-        member this.GetLoopOutQuote(request: SwapDTO.LoopOutQuoteRequest, ?ct: CancellationToken): Task<SwapDTO.LoopOutQuote> =
+        member this.GetLoopOutQuote(request: SwapDTO.LoopOutQuoteRequest, ?ct: CancellationToken): Task<Result<SwapDTO.LoopOutQuote, string>> =
           parameters.LoopOutQuote request
 
-        member this.GetLoopInQuote(request: SwapDTO.LoopInQuoteRequest, ?ct: CancellationToken): Task<SwapDTO.LoopInQuote> =
+        member this.GetLoopInQuote(request: SwapDTO.LoopInQuoteRequest, ?ct: CancellationToken): Task<Result<SwapDTO.LoopInQuote, string>> =
           parameters.LoopInQuote request
 
         member this.GetLoopOutTerms(req, ?ct : CancellationToken): Task<SwapDTO.OutTermsResponse> =
@@ -349,6 +349,9 @@ type TestHelpers =
 
         member this.GetDepositAddress(_network, _ct) =
           p.GetDepositAddress() |> Task.FromResult
+
+        member this.GetSendingTxFee(destinations, target, ct) =
+          failwith "todo"
     }
 
   static member GetDummySwapExecutor(?_parameters) =


### PR DESCRIPTION
When we query the quote from the server in autoloop, before this commit
it uses an on-chain fees estimated by them, This will be imcompatible when
actually executing the swap. Because we use a feerate estimated by our
FeeEstimator. This commit fixes it by using FeeEstimator also when getting
loopin/out quotes.