### PR TITLE
commit error in swap actor

### DIFF
--- a/NLoop.Domain/DomainUtils/DomainUtils.fs
+++ b/NLoop.Domain/DomainUtils/DomainUtils.fs
@@ -373,7 +373,8 @@ type IActor<'TState, 'TCommand, 'TEvent, 'TError, 'TEntityId, 'T when 'T : compa
   abstract member Execute:
     swapId: 'TEntityId *
     msg: 'TCommand *
-    ?source: string
+    ?source: string *
+    ?commitErrorOnFailure: bool
       -> Task
 
   // todo: use asyncSeq

--- a/NLoop.Server/BlockChainListeners/BlockChainListener.fs
+++ b/NLoop.Server/BlockChainListeners/BlockChainListener.fs
@@ -85,7 +85,7 @@ type BlockchainListener(
         |> Swap.Command.NewBlock
       do!
         swaps.Keys
-        |> Seq.map(fun s -> actor.Execute(s, cmd, nameof(BlockchainListener)))
+        |> Seq.map(fun s -> actor.Execute(s, cmd, nameof(BlockchainListener), true))
         |> Task.WhenAll
       this.CurrentTip <- newB
   }
@@ -94,7 +94,7 @@ type BlockchainListener(
     let cmd = (Swap.Command.UnConfirmBlock(blockHash))
     do!
       swaps.Keys
-      |> Seq.map(fun s -> actor.Execute(s, cmd, nameof(BlockchainListener)))
+      |> Seq.map(fun s -> actor.Execute(s, cmd, nameof(BlockchainListener), true))
       |> Task.WhenAll
   }
 

--- a/NLoop.Server/ProcessManagers/SwapProcessManager.fs
+++ b/NLoop.Server/ProcessManagers/SwapProcessManager.fs
@@ -47,7 +47,7 @@ type SwapProcessManager(eventAggregator: IEventAggregator,
               }
               |> Swap.Command.OffChainOfferResolve
             do!
-              actor.Execute(swapId, cmd, $"{nameof(SwapProcessManager)}-{nameof(waitToOfferGetsResolved)}")
+              actor.Execute(swapId, cmd, $"{nameof(SwapProcessManager)}-{nameof(waitToOfferGetsResolved)}", true)
               |> Async.AwaitTask
           | OutgoingInvoiceStateUnion.Failed ->
             let msg = "Offchain payment failed"

--- a/NLoop.Server/Services/BoltzListener.fs
+++ b/NLoop.Server/Services/BoltzListener.fs
@@ -43,7 +43,7 @@ type BoltzListener(swapServerClient: ISwapServerClient,
           if not <| finished then
             let! swapId, tx = updateQueue.Reader.ReadAsync(ct)
             logger.LogInformation $"boltz notified about their swap tx ({tx.ToHex()}) for swap {swapId}"
-            do! actor.Execute(swapId, Swap.Command.CommitSwapTxInfoFromCounterParty(tx.ToHex()), nameof(BoltzListener))
+            do! actor.Execute(swapId, Swap.Command.CommitSwapTxInfoFromCounterParty(tx.ToHex()), nameof(BoltzListener), true)
             statuses.TryRemove(swapId) |> ignore
       with
       | :? OperationCanceledException ->

--- a/tests/NLoop.Server.Tests/TestHelpersMod.fs
+++ b/tests/NLoop.Server.Tests/TestHelpersMod.fs
@@ -334,7 +334,7 @@ type TestHelpers =
             failwith "todo"
         member this.Aggregate =
           failwith "todo"
-        member this.Execute(swapId, msg, source) =
+        member this.Execute(swapId, msg, source, commitError) =
           p.Execute(swapId, msg, source); Task.CompletedTask
         member this.GetAllEntities(_since, _ct) =
           failwith "todo"


### PR DESCRIPTION
When swap fails with unexpected reason. Currently it does not re-commit the
error and thus pending forever.
This commit fixes it by re-commiting when specified so.