### PR TITLE
Scan tx inputs/outputs for claim tx

### DIFF
--- a/NLoop.Server/Services/BlockchainProxies.fs
+++ b/NLoop.Server/Services/BlockchainProxies.fs
@@ -38,6 +38,8 @@ type BitcoinRPCBroadcaster(getClient: GetBlockchainClient, logger: ILogger<Bitco
       | :? RPCException as ex when ex.Message.Contains "Transaction already in block" ->
         // same tx already in the chain, do nothing.
         logger.LogInformation("Failed to broadcast {Tx}, tx already in mempool", tx.ToHex())
+      | :? RPCException as ex when ex.Message.Contains "bad-txns-inputs-missingorspent" ->
+        logger.LogInformation("Failed to broadcast {Tx}, inputs has been spent", tx.ToHex())
         ()
     }
 


### PR DESCRIPTION
Sometimes, when we bump the claim tx, an old tx gets confirmed.
Before this commit, we were checking the claim tx by its id, but
id does change when bump it. ending up "bad-txns-inputs-missingorspent"
error when broadcasting tx by missing the claim tx confirmed.
Now we check claimtx not only by its id but also with inputs/outputs for
more robust claim tx detection.