### PR TITLE
CI: generate release notes automatically

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - enhancement
+    - title: Bug fixes 🐛
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,5 +76,5 @@ jobs:
           files: |
             nloopd.${{ matrix.RID }}.gz
             nloop-cli.${{ matrix.RID }}.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          generate_release_notes: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Testing [automatic release note generation feature of github](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)

