### PR TITLE
Serialize metadata correctly

### DIFF
--- a/NLoop.Domain/DomainUtils/DomainUtils.EventStore.Subscription.fs
+++ b/NLoop.Domain/DomainUtils/DomainUtils.EventStore.Subscription.fs
@@ -151,7 +151,7 @@ type EventStoreDBSubscription(eventStoreConfig: EventStoreConfig,
 
   let rec watch (mailbox: SubscriptionMailbox) = async {
     let! state = mailbox.PostAndAsyncReply(GetState)
-    log.LogDebug($"Stream {streamId} is at checkpoint {state.Checkpoint}")
+    log.LogTrace($"Stream {streamId} is at checkpoint {state.Checkpoint}")
     do! Async.Sleep (TimeSpan.FromMinutes(5.))
     return! watch mailbox
   }

--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@ Check [README.md in test project](./tests/NLoop.Server.Tests/README.md)
 
 Check out our [`openapi.yml`](./openapi.yml) (or [its rendered version](https://bitbankinc.github.io/NLoop/)) for the REST API specification.
 
-There is a one endpoint which is not included in the spec.
-That is a WebSocket endpoint for listening to events.
-* `/v1/events`
+### Subscribing to events
+
+If you want to react to the changes caused by nloop, (e.g. notify to slack/discord when the swap starts and/or finished.)
+we recommend subscribing to eventstoredb directly rather than long-polling the api.
+Please see [the official documentation](https://developers.eventstore.com/clients/dotnet/5.0/subscriptions.html) for how to.
+Actual object you get is json-encoded [Events](https://github.com/bitbankinc/NLoop/blob/master/NLoop.Domain/Swap.fs#L299) with metadata.
 
 ## configuration options
 

--- a/tests/NLoop.Server.Tests/README.md
+++ b/tests/NLoop.Server.Tests/README.md
@@ -43,6 +43,8 @@ curl http://localhost:5000/v1/info
 
 ```
 
+You can access http://localhost:2113 for EventStoreDB admin ui to check the current state of the db.
+
 To reset the state, you can just run the following commands after stopping the docker-compose.
 
 ```sh

--- a/tests/NLoop.Server.Tests/docker-compose.yml
+++ b/tests/NLoop.Server.Tests/docker-compose.yml
@@ -304,9 +304,13 @@ services:
     ports:
       - "1113:1113"
       - "2113:2113"
-    command: --enable-external-tcp --ext-ip=0.0.0.0 --int-ip=0.0.0.0 --ext-host-advertise-as=esdb --advertise-host-to-client-as=localhost
-      #- --enable-external-tcp
-      #- --enable-external-http
+    command:
+      - --enable-external-tcp
+      - --ext-ip=0.0.0.0
+      - --int-ip=0.0.0.0
+      - --ext-host-advertise-as=esdb
+      - --advertise-host-to-client-as=localhost
+      - --enable-atom-pub-over-http
     volumes:
       - "./data/esdb:/etc/eventstore"
 


### PR DESCRIPTION
BREAKING CHANGE: serialize event metadata as json.
    
Before this commit, we were using custom binary serialization
for Event metadata. But those are unparsable by eventstoredb.
    
So just use JsonSerializer to serialize to utf8json -> byte array
which is more simple and now eventstoredb subscriber can read the metadata.
    
This is (hopefully the last) breaking change.

